### PR TITLE
66 - Chybné načítání validací

### DIFF
--- a/VerteMark/MainWindows/MainWindow.xaml.cs
+++ b/VerteMark/MainWindows/MainWindow.xaml.cs
@@ -97,7 +97,6 @@ namespace VerteMark
 
             // zvalidneni vsech anotaci, pokud je user validator:
             if ( loggedInUser != null && loggedInUser.Validator) {
-                utility.ValidateAll();
                 savingParam = 2;
             }
 

--- a/VerteMark/MainWindows/MainWindow.xaml.cs
+++ b/VerteMark/MainWindows/MainWindow.xaml.cs
@@ -97,6 +97,7 @@ namespace VerteMark
 
             // zvalidneni vsech anotaci, pokud je user validator:
             if ( loggedInUser != null && loggedInUser.Validator) {
+                //utility.ValidateAll()
                 savingParam = 2;
             }
 

--- a/VerteMark/ObjectClasses/Project.cs
+++ b/VerteMark/ObjectClasses/Project.cs
@@ -326,6 +326,13 @@ namespace VerteMark.ObjectClasses
             }
         }
 
+        /*
+        public void ValidateAll() {
+            foreach (Anotace annotation in anotaces) {
+                annotation.Validate(true);
+            }
+        }
+        */
 
         public List<Anotace> GetAnotaces(){
             return anotaces;

--- a/VerteMark/ObjectClasses/Project.cs
+++ b/VerteMark/ObjectClasses/Project.cs
@@ -285,7 +285,7 @@ namespace VerteMark.ObjectClasses
 
         public void ValidateAnnotationByID(int id) {
             Anotace anotace = FindAnotaceById(id);
-            Debug.WriteLine("ZAVOLANA VALIDACE");
+            Debug.WriteLine("ZAVOLANA VALIDACE TLACITKO");
             if (anotace.IsValidated) {
                 anotace.Validate(false);
                 Debug.WriteLine("FALSE");
@@ -326,11 +326,6 @@ namespace VerteMark.ObjectClasses
             }
         }
 
-        public void ValidateAll() {
-            foreach (Anotace annotation in anotaces) {
-                annotation.Validate(true);
-            }
-        }
 
         public List<Anotace> GetAnotaces(){
             return anotaces;

--- a/VerteMark/ObjectClasses/Utility.cs
+++ b/VerteMark/ObjectClasses/Utility.cs
@@ -85,6 +85,11 @@ namespace VerteMark.ObjectClasses
             project.DeleteTempFolder();
         }
 
+        /* Pro zvalidování všech anotací najednou
+        public void ValidateAll() {
+            project.ValidateAll();
+        }
+        */
 
         public List<Anotace> GetAnnotationsList(){
             return project.GetAnotaces();

--- a/VerteMark/ObjectClasses/Utility.cs
+++ b/VerteMark/ObjectClasses/Utility.cs
@@ -85,9 +85,6 @@ namespace VerteMark.ObjectClasses
             project.DeleteTempFolder();
         }
 
-        public void ValidateAll() {
-            project.ValidateAll();
-        }
 
         public List<Anotace> GetAnnotationsList(){
             return project.GetAnotaces();


### PR DESCRIPTION
Bug z minulé implementace, kdy validátor měl dostat při načtění defaultně všechny zvalidované anotace. Toto zvalidování se nepropsalo do checkboxů (tvářily se, že zvalidované nejsou, ale byly)

Odstranění této fíčury (možná obnova do budoucna)